### PR TITLE
build system addition for macos (Mojave, 10.14)

### DIFF
--- a/inc/bmem.h
+++ b/inc/bmem.h
@@ -41,7 +41,7 @@
 
 #include "os.h"
 #include <stdlib.h>
-#if !defined(__CMS__) && !defined(__MVS__)
+#if !defined(__CMS__) && !defined(__MVS__) && !defined(__APPLE__)
 #	include <malloc.h>
 #endif
 

--- a/inc/rexx.h
+++ b/inc/rexx.h
@@ -257,7 +257,9 @@ RxFile*	__CDECL RxFileAlloc( char *fname );
 void	__CDECL RxFileFree( RxFile *rxf );
 void	__CDECL RxFileType( RxFile *rxf );
 int	__CDECL RxFileLoad( RxFile *rxf );
-int	__CDECL RxLoadLibrary( PLstr libname, bool shared );
+#ifndef __APPLE__
+  int	__CDECL RxLoadLibrary( PLstr libname, bool shared );
+#endif
 int	__CDECL RxRun( char *filename, PLstr programstr,
 		PLstr arguments, PLstr tracestr, char *environment );
 

--- a/lstring/makefile
+++ b/lstring/makefile
@@ -100,6 +100,7 @@ OBJECTS = $(SOURCES:.c=.o)
 .c.o:
 	$(CC) -c $(CCOPTIONS) $<
 
+
 ############# TARGETS #############
 
 default:
@@ -110,9 +111,14 @@ $(LIBDIR)/$(LSTR_LIB):	$(OBJECTS)
 	$(RM) $@
 	$(MAKELIB) $@ $^
 
+
 ifeq ($(STATIC),no)
 $(LIBDIR)/$(LSTR_SO):	$(OBJECTS)
+ifeq ($(MACOS), yes)
+	$(CC) -o $(LSTR_SO) -dynamiclib *.o $(LDEXTRA) $(LIBEXTRA)
+else
 	$(CC) $(CCOPTIONS) -shared -Wl,-soname,$(LSTR_SO) -o $@ $^ $(LDEXTRA)
+endif
 
 targets: $(LIBDIR)/$(LSTR_LIB) $(LIBDIR)/$(LSTR_SO)
 

--- a/make.cnf
+++ b/make.cnf
@@ -300,7 +300,7 @@ macos:
 	"STATIC = no" \
 	"EXTRA = " \
 	"LSTR_SO   = liblstring.dylib" \
-	"CFLAGS = -O3 -fno-stack-protector -fpic -DALIGN -DINLINE -DHAVE_SETENV -DHAVE_READLINE" \
+	"CFLAGS = -O3 -Wno-format -Wno-format-security -Wno-implicit-function-declaration -Wno-pointer-sign -Wno-empty-body -fno-stack-protector -fpic -DALIGN -DINLINE -DHAVE_SETENV -DHAVE_READLINE" \
 	"LDEXTRA = -lreadline  -ldl -lm" \
 	"LIBEXTRA = -lreadline  -ldl -lm -Wl,-rpath"
 

--- a/make.cnf
+++ b/make.cnf
@@ -178,7 +178,7 @@ linux:
 	"CC = gcc" \
 	"STATIC = no" \
 	"EXTRA = " \
-	"CFLAGS = -O2 -fno-stack-protector -fpic -rdynamic -DALIGN -DINLINE -DHAVE_SETENV -DHAVE_READLINE" \
+	"CFLAGS = -O2 -fno-stack-protector -fpic -DALIGN -DINLINE -DHAVE_SETENV -DHAVE_READLINE" \
 	"LDEXTRA = -nostdlib -lreadline -lnsl -ldl -lm" \
 	"LIBEXTRA = -lreadline -lnsl -ldl -lm -Wl,-rpath"
 
@@ -292,4 +292,15 @@ test_debug:
 	"CC = gcc" \
 	"MAIN = maintest.c" \
 	"CFLAGS = -g -pg -Wall -DALIGN -D__DEBUG__ -DHAVE_SETENV"
+
+macos:
+	$(MAKE) targets \
+	"CC = gcc" \
+	"MACOS = yes" \
+	"STATIC = no" \
+	"EXTRA = " \
+	"LSTR_SO   = liblstring.dylib" \
+	"CFLAGS = -O3 -fno-stack-protector -fpic -DALIGN -DINLINE -DHAVE_SETENV -DHAVE_READLINE" \
+	"LDEXTRA = -lreadline  -ldl -lm" \
+	"LIBEXTRA = -lreadline  -ldl -lm -Wl,-rpath"
 

--- a/makefile
+++ b/makefile
@@ -42,7 +42,7 @@ TARGETS =	aix aix_debug \
 		linux_intel linux_intel_debug \
 		linux_noalign linux_noalign_debug \
 		cegcc cegcc_debug \
-		test test_debug \
+		test test_debug macos \
 		install
 
 default:
@@ -68,7 +68,8 @@ default:
 	@echo "  make linux64              for Linux 64bit systems with GCC *"
 	@echo "  make linux_intel          for Linux systems with intel compiler,"
 	@echo "  make linux_noalign        for Linux systems with GCC,"
-	@echo "  make macintosh            for a Mac application"
+	@echo "  make macintosh            for a Mac (pre-Mac OPSX) application"
+	@echo "  make macos                for a macos application"
 	@echo "  make mswindows            for Microsoft Windows"
 	@echo "  make test                 for testing/experimenting"
 	@echo "  make tar                  to prepare a .tar.gz file"

--- a/modules/makefile
+++ b/modules/makefile
@@ -33,8 +33,11 @@ endif
 
 ############# MACROS ##############
 OBJECTS = $(SOURCES:.c=.o)
+ifeq ($(MACOS), yes)
+SOS     = $(SOURCES:.c=.dylib)
+else
 SOS     = $(SOURCES:.c=.so)
-
+endif
 ############# RULES ###############
 
 .c.o:
@@ -42,6 +45,10 @@ SOS     = $(SOURCES:.c=.so)
 
 %.so: %.o
 	$(CC) $(CCOPTIONS) -shared -Wl,-soname,$@ -o $@ $< -L../lstring -llstring $(LDEXTRA)
+
+%.dylib: %.o
+	$(CC) $(CCOPTIONS) -o $@ -dynamiclib -Wl,-U $< -L../lstring -llstring $(LDEXTRA) -rpath
+
 
 ############# TARGETS #############
 

--- a/src/bmem.c
+++ b/src/bmem.c
@@ -47,7 +47,7 @@
 #include <ctype.h>
 #include <stdio.h>
 
-#if !defined(__CMS__) && !defined(__MVS__)
+#if !defined(__CMS__) && !defined(__MVS__) && !defined(__APPLE__)
 #	include <malloc.h>
 #endif
 

--- a/src/makefile
+++ b/src/makefile
@@ -58,6 +58,10 @@ $(REXX_EXE):	$(OBJECTS)
 else
 $(REXX_EXE):	$(OBJECTS)
 	$(CC) -o $@ $(CCOPTIONS) $^ $(LIBDIR)/$(LSTR_SO) $(LIBEXTRA)
+ifeq ($(MACOS),yes)
+	cp rexx brexx
+	install_name_tool -change liblstring.dylib @loader_path/../lstring/liblstring.dylib brexx
+endif
 endif
 
 install:

--- a/src/makefile
+++ b/src/makefile
@@ -59,7 +59,7 @@ else
 $(REXX_EXE):	$(OBJECTS)
 	$(CC) -o $@ $(CCOPTIONS) $^ $(LIBDIR)/$(LSTR_SO) $(LIBEXTRA)
 ifeq ($(MACOS),yes)
-	cp rexx brexx
+	mv rexx brexx
 	install_name_tool -change liblstring.dylib @loader_path/../lstring/liblstring.dylib brexx
 endif
 endif

--- a/src/rexx.c
+++ b/src/rexx.c
@@ -314,7 +314,7 @@ int __CDECL
 RxLoadLibrary( PLstr libname, bool shared )
 {
 	RxFile  *rxf, *last;
-#if defined(UNIX) || defined(__CMS__) || defined(__MVS__)
+#if defined(UNIX) || defined(__CMS__) || defined(__MVS__) || defined(__APPLE__)
 	Lstr	tmpstr;
 	char	*dlerrorstr;
 #endif


### PR DESCRIPTION
Hi Dr Vlachoudis, I added support for building on Apple macos (what used to be called Mac OSX). This supports building with dynamic libraries, I followed the structure of your build system. I checked builds on Linux, which still work. Loading external libraries does not work yet, but I would like to merge because otherwise it would drag on and maybe will be harder to merge.

I had some trouble with the prototype of RxLoadLibrary in rexx.c; clang complained about 'already declared' but I did not see why, so I conditionally declare it. Other changes are trivial, and I did switch off some compiler warnings because they cluttered up the build and seemed irrelevant.

I will try to fix the library loading when I have more time. Basic functionality works OK and I am greatly impressed by the performance.

best regards,

René Jansen. 