### PR TITLE
Fixed unset var in stem

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -369,12 +369,8 @@ RxVarFind(const Scope scope, const PBinLeaf litleaf, bool *found)
 		stemscope = ((Variable*)(leaf->value))->stem;
 
 		if (stemscope==NULL) {
-			if (!LISNULL(*LEAFVAL(leaf)))
-				Lstrcpy(&stemvaluenotfound, LEAFVAL(leaf));
-			else {
-				Lstrcpy(&stemvaluenotfound,varname);
-				Lstrcat(&stemvaluenotfound,&varidx);
-			}
+			Lstrcpy(&stemvaluenotfound,varname);
+			Lstrcat(&stemvaluenotfound,&varidx);
 			*found = FALSE;
 			return leaf;
 		}
@@ -428,12 +424,8 @@ RxVarFind(const Scope scope, const PBinLeaf litleaf, bool *found)
 
 		if (leafidx==NULL) {	/* not found */
 			*found = FALSE;
-			if (!LISNULL(*LEAFVAL(leaf)))
-				Lstrcpy(&stemvaluenotfound, LEAFVAL(leaf));
-			else {
-				Lstrcpy(&stemvaluenotfound,varname);
-				Lstrcat(&stemvaluenotfound,&varidx);
-			}
+			Lstrcpy(&stemvaluenotfound,varname);
+			Lstrcat(&stemvaluenotfound,&varidx);
 			return leaf;	/* return stem leaf */
 		} else {
 			*found = TRUE;
@@ -514,12 +506,8 @@ RxVarFindName(Scope scope, PLstr name, bool *found)
 		stemscope = ((Variable*)(leaf->value))->stem;
 
 		if (stemscope==NULL) {
-			if (!LISNULL(*LEAFVAL(leaf)))
-				Lstrcpy(&stemvaluenotfound,LEAFVAL(leaf));
-			else {
-				Lstrcpy(&stemvaluenotfound,varname);
-				Lstrcat(&stemvaluenotfound,&varidx);
-			}
+			Lstrcpy(&stemvaluenotfound,varname);
+			Lstrcat(&stemvaluenotfound,&varidx);
 			*found = FALSE;
 			return leaf;
 		}
@@ -544,12 +532,8 @@ RxVarFindName(Scope scope, PLstr name, bool *found)
 
 		if (leafidx==NULL) {	/* not found */
 			*found = FALSE;
-			if (!LISNULL(*LEAFVAL(leaf)))
-				Lstrcpy(&stemvaluenotfound,LEAFVAL(leaf));
-			else {
-				Lstrcpy(&stemvaluenotfound,varname);
-				Lstrcat(&stemvaluenotfound,&varidx);
-			}
+			Lstrcpy(&stemvaluenotfound,varname);
+			Lstrcat(&stemvaluenotfound,&varidx);
 			return leaf;	/* return stem leaf */
 		} else {
 			*found = TRUE;


### PR DESCRIPTION
The code checked !LISNULL(*LEAFVAL(leaf)) to decide what to put in stemvaluenotfound:

- If the stem leaf had a value → it used that value (e.g., "1 hi mom" if that was the stem's stale value)
- Otherwise → it constructed the variable name ("Z.2") The stem leaf's value can become non-NULL through various operations (RxVarDel, RxVarExpose, etc.), causing the wrong value to leak through. The fix always constructs varname + varidx (e.g., Z.2) regardless of whether the stem leaf has a value, matching VM/SP5 behavior.

See https://github.com/s390guy/vm370/issues/176