### PR TITLE
Fixed function call mid-expression

### DIFF
--- a/src/interpre.c
+++ b/src/interpre.c
@@ -1112,11 +1112,14 @@ outofcmd:
 			/* check to see if we have allready its position */
 			if (inf->id == Rx_id) {
 				leaf = inf->leaf[0];
-				STACKTOP = LEAFVAL(leaf);
+				Lstrcpy(&(_tmpstr[RxStckTop]),LEAFVAL(leaf));
+				STACKTOP = &(_tmpstr[RxStckTop]);
 			} else {
 				leaf = RxVarFind(VarScope, litleaf, &found);
-				if (found)
-					STACKTOP = LEAFVAL(leaf);
+				if (found) {
+						Lstrcpy(&(_tmpstr[RxStckTop]),LEAFVAL(leaf));
+						STACKTOP = &(_tmpstr[RxStckTop]);
+					}
 				else {
 					if (inf->stem) {
 						/* Lstrcpy to a temp variable */

--- a/src/interpre.c
+++ b/src/interpre.c
@@ -1117,10 +1117,9 @@ outofcmd:
 			} else {
 				leaf = RxVarFind(VarScope, litleaf, &found);
 				if (found) {
-						Lstrcpy(&(_tmpstr[RxStckTop]),LEAFVAL(leaf));
-						STACKTOP = &(_tmpstr[RxStckTop]);
-					}
-				else {
+					Lstrcpy(&(_tmpstr[RxStckTop]),LEAFVAL(leaf));
+					STACKTOP = &(_tmpstr[RxStckTop]);
+				} else {
 					if (inf->stem) {
 						/* Lstrcpy to a temp variable */
 						Lstrcpy(&(_tmpstr[RxStckTop]),&stemvaluenotfound);


### PR DESCRIPTION
Replace STACKTOP = LEAFVAL(leaf) (direct pointer to variable's value) with a copy to _tmpstr + pointer to that copy, so a function call mid-expression can't corrupt the snapshot.