### PR TITLE
Segmentation fault in Lstrcpy() under INTERPRET

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+mm/yyyy
+    * Release x.y.z
+		Fix issue #9: SIGL not set
 04/2011 Vasilis Vlachoudis <Vasilis.Vlachoudis@cern.ch>
 	* Release 2.1.9:
 		Support for ANDROID

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 mm/yyyy
     * Release x.y.z
+		Fix issue #14: Segmentation fault in Lstrcpy() under INTERPRET
 		Fix issue #9: SIGL not set
 04/2011 Vasilis Vlachoudis <Vasilis.Vlachoudis@cern.ch>
 	* Release 2.1.9:

--- a/inc/compile.h
+++ b/inc/compile.h
@@ -47,6 +47,15 @@
 #define SYMBOLADD2LITS		_Add2Lits(&symbolstr,symbolhasdot)
 #define	SYMBOLADD2LITS_KEY	&(((PBinLeaf)SYMBOLADD2LITS)->key)
 
+#ifndef ALIGN
+#define CODEFIXUPB(p,v) *(byte *)(LSTR(*CompileCode) + (p)) = (v)
+#define CODEFIXUP(p,v) *(word *)(LSTR(*CompileCode) + (p)) = (v)
+#define CLAUSESTEP      sizeof(byte)
+#else
+#define CODEFIXUP(p,v) *(dword *)(LSTR(*CompileCode) + (p)) = (v)
+#define CODEFIXUPB(p,v) CODEFIXUP(p,v)
+#define CLAUSESTEP      sizeof(dword)
+#endif
 /* ----------- Function structure ----------- */
 enum functypes {
 	FT_LABEL,

--- a/src/compile.c
+++ b/src/compile.c
@@ -77,15 +77,6 @@
 */
 
 /* ------------ local defines ------------ */
-#ifndef ALIGN
-#define CODEFIXUPB(p,v) *(byte *)(LSTR(*CompileCode) + (p)) = (v)
-#define CODEFIXUP(p,v) *(word *)(LSTR(*CompileCode) + (p)) = (v)
-#define CLAUSESTEP	sizeof(byte)
-#else
-#define CODEFIXUP(p,v) *(dword *)(LSTR(*CompileCode) + (p)) = (v)
-#define CODEFIXUPB(p,v) CODEFIXUP(p,v)
-#define CLAUSESTEP	sizeof(dword)
-#endif
 
 /* ---- function prototypes ---- */
 int	__CDECL C_expr( int );

--- a/src/interpre.c
+++ b/src/interpre.c
@@ -1284,6 +1284,10 @@ outofcmd:
 
 			if (func->label==UNKNOWN_LABEL)
 				Lerror(ERR_UNEXISTENT_LABEL,1,&(leaf->key));
+
+			/* Set SIGL to the line we're jumping from. */
+			RxSetSpecialVar(SIGLVAR, TraceCurline(NULL, FALSE));
+
 			/* jump */
 			Rxcip=(CIPTYPE*)((byte huge *)Rxcodestart+func->label);
 			goto main_loop;
@@ -1302,6 +1306,9 @@ outofcmd:
 
 			/* clear stack */
 			RxStckTop = _proc[_rx_proc].stacktop;
+
+			/* Set SIGL to the line we're jumping from. */
+			RxSetSpecialVar(SIGLVAR, TraceCurline(NULL, FALSE));
 
 			/* jump */
 			Rxcip = (CIPTYPE*)((byte huge *)Rxcodestart + (size_t)(func->label));

--- a/src/interpre.c
+++ b/src/interpre.c
@@ -1403,7 +1403,8 @@ outofcmd:
 /**
 // It is possible to do a DUP in the compile code of returnf
 **/
-				Lstrcpy(_proc[_rx_proc].arg.r, STACKTOP);
+				if (_proc[_rx_proc].arg.r)
+					Lstrcpy(_proc[_rx_proc].arg.r, STACKTOP); /* Copy result if caller wants it. */
 			else {
 				/* is the Variable space private? */
 				/* proc: PROCEDURE */


### PR DESCRIPTION
Fix #14 .

Fix summary from https://github.com/adesutherland/CMS-370-BREXX/issues/77, lightly editted:

----
The failure happens when [`interpre.c`](https://github.com/RossPatterson/CMS-370-BREXX/blob/develop/interpre.c#L1671) attempts to pass back the value from a `RETURN value` instruction to the caller:

```c
Lstrcpy(_proc[_rx_proc].arg.r, STACKTOP);
```

The problem is that `arg.r` can be `NULL`, because `rexx.c:RxRun()` [initializes it that way](https://github.com/RossPatterson/CMS-370-BREXX/blob/develop/rexx.c#L407):
```c
pr->arg.r = NULL;
```
On CMS, that leads to a PROG004, when `Lstrcpy()` tries to copy part of the `Lstr` structure to location X'00000C`.  It may also cause other effects, depending on what's in location X'000000'.  On Unixy systems, it causes a [segmentation fault](https://github.com/vlachoudis/brexx/issues/14) because location 0 isn't mapped into process memory.

The only other code that sets it is in `interpre.c:I_MakeArgs()`, which [puts it on the stack](https://github.com/RossPatterson/CMS-370-BREXX/blob/develop/interpre.c#L619):
```c
arg->r = (context->interpre_RxStck)[st];
```

and `interpre.c:RxInitInterStr()`, which also [sets it to NULL](https://github.com/RossPatterson/CMS-370-BREXX/blob/develop/interpre.c#L899):

```c
(pr->arg).r = NULL;
```
...

The semi-obvious fix is to protect the call to `Lstrcpy()` with a check to see if `arg.r` is `NULL`, and to skip the copy if so.  The code path has, at that point, effectively declared that it is uninterested in the result of the function call.

----

Test case:
```rexx
/* test_14.rexx */
trace i
Interpret 'Return F()'
Exit

F: Procedure
Return 2
```

Before:
```rexx
ross@RP-I3511:/mnt/c/Ross/Source/VM/BREXX/brexx-rp$ brexx test_14.rexx
     3 *-* Interpret 'Return F()'
       >L>   "Return F()"
     1 *-*  Return F()
     6 *-*   F: Procedure
     7 *-*
       >L>     "2"
Segmentation fault (core dumped)
```

After:
```rexx
ross@RP-I3511:/mnt/c/Ross/Source/VM/BREXX/brexx-rp$ src/rexx test_14.rexx
     3 *-* Interpret 'Return F()'
       >L>   "Return F()"
     1 *-*  Return F()
     6 *-*   F: Procedure
     7 *-*
       >L>     "2"
     4 *-* Exit
```